### PR TITLE
feat: support relations that are not associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,41 +178,50 @@ The only change on calculate routes is the `selects` paramater contains the func
 
 # Testing
 
+To run the test suite, do the following:
+
+```
+$ createdb standardapi-test
+$ bundle exec rake test
+```
+
 And example contoller and it's tests.
 
-    class PhotosController < ApplicationController
-        include StandardAPI
+```rb
+class PhotosController < ApplicationController
+  include StandardAPI
 
-        # If you have actions you don't want include be sure to hide them,
-        # otherwise if you include StandardAPI::TestCase and you don't have the
-        # action setup, the test will fail.
-        hide_action :destroy
+  # If you have actions you don't want include be sure to hide them,
+  # otherwise if you include StandardAPI::TestCase and you don't have the
+  # action setup, the test will fail.
+  hide_action :destroy
 
-        # Allowed params
-        def photo_params
-          [:id, :file, :caption]
-        end
-  
-        # Allowed orderings
-        def photo_orders
-          [:id, :created_at, :updated_at, :caption]
-        end
+  # Allowed params
+  def photo_params
+    [:id, :file, :caption]
+  end
 
-        # Allowed includes
-        # You can include the author and the authors photos in the JSON response
-        def photo_includes
-          { :author => [:photos] }
-        end
+  # Allowed orderings
+  def photo_orders
+    [:id, :created_at, :updated_at, :caption]
+  end
 
-        # Mask for Photo. Provide this method if you want to mask some records
-        # The mask is then applyed to all actions when querring ActiveRecord
-        # Will only allow photos that have id one. For more on the syntax see
-        # the activerecord-filter gem.
-        def mask_for(table_name)
-            { id: 1 }
-        end
+  # Allowed includes
+  # You can include the author and the authors photos in the JSON response
+  def photo_includes
+    { :author => [:photos] }
+  end
 
-    end
+  # Mask for Photo. Provide this method if you want to mask some records
+  # The mask is then applyed to all actions when querring ActiveRecord
+  # Will only allow photos that have id one. For more on the syntax see
+  # the activerecord-filter gem.
+  def mask_for(table_name)
+      { id: 1 }
+  end
+
+end
+```
 
 # Usage
 

--- a/lib/standard_api/views/application/_record.json.jbuilder
+++ b/lib/standard_api/views/application/_record.json.jbuilder
@@ -60,6 +60,22 @@ includes.each do |inc, subinc|
           partial = model_partial(value)
           json.partial! partial, partial.split('/').last.to_sym => value, includes: subinc
         end
+      elsif value.is_a?(ActiveRecord::Relation)
+        json.set! inc do
+          partial = model_partial(value.klass)
+  
+          # TODO limit causes preloaded assocations to reload
+          sub_records = record.send(inc)
+  
+          sub_records = sub_records.limit(subinc['limit']) if subinc['limit']
+          sub_records = sub_records.offset(subinc['offset']) if subinc['offset']
+          sub_records = sub_records.reorder(subinc['order']) if subinc['order']
+          sub_records = sub_records.filter(subinc['where']) if subinc['where']
+          sub_records = sub_records.distinct if subinc['distinct']
+          sub_records = sub_records.distinct_on(subinc['distinct_on']) if subinc['distinct_on']
+  
+          json.array! sub_records, partial: partial, as: partial.split('/').last, locals: { includes: subinc }
+        end
       else
         json.set! inc, value.as_json
       end

--- a/lib/standard_api/views/application/_record.streamer
+++ b/lib/standard_api/views/application/_record.streamer
@@ -61,6 +61,22 @@ json.object! do
             partial = model_partial(value)
             json.partial! partial, partial.split("/").last.to_sym => value, includes: subinc
           end
+        elsif value.is_a?(ActiveRecord::Relation)
+          json.set! inc do
+            partial = model_partial(value.klass)
+    
+            # TODO limit causes preloaded assocations to reload
+            sub_records = record.send(inc)
+    
+            sub_records = sub_records.limit(subinc['limit']) if subinc['limit']
+            sub_records = sub_records.offset(subinc['offset']) if subinc['offset']
+            sub_records = sub_records.reorder(subinc['order']) if subinc['order']
+            sub_records = sub_records.filter(subinc['where']) if subinc['where']
+            sub_records = sub_records.distinct if subinc['distinct']
+            sub_records = sub_records.distinct_on(subinc['distinct_on']) if subinc['distinct_on']
+    
+            json.array! sub_records, partial: partial, as: partial.split('/').last, locals: { includes: subinc }
+          end
         else
           json.set! inc, value.as_json
         end


### PR DESCRIPTION
In your ACL file, you can specify a computed method as an included attribute. But if your computed method returns an `ActiveRecord::Relation`, you might want to traverse the associations/methods on the resultant `ActiveRecord::Relation`. This change allows you do so.